### PR TITLE
papertrail@2.1.0: bumped papertrail version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-logs-to-provider",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "This extension will take all of your Auth0 logs and export them to any provider from the list.",
   "main": "index.js",
   "repository": {

--- a/webtask-templates/papertrail.json
+++ b/webtask-templates/papertrail.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 Logs to Papertrail",
   "name": "auth0-logs-to-papertrail",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "This extension will take all of your Auth0 logs and export them to Papertrail",
   "docsUrl": "https://auth0.com/docs/extensions/papertrail",
   "logoUrl": "https://cdn.auth0.com/extensions/auth0-logs-to-papertrail/assets/logo.png",


### PR DESCRIPTION
## ✏️ Changes
  
- bumped `papertrail` extension version from `2.0.3` to `2.1.0`
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/KEY-352
 
