### PR TITLE
fixed log types for segment

### DIFF
--- a/server/lib/processLogs.js
+++ b/server/lib/processLogs.js
@@ -83,6 +83,8 @@ module.exports = (storage) =>
 
     if (provider === 'mgmt-webhooks') {
       options.logTypes = [ 'sapi', 'fapi' ];
+    } else if (provider === 'segment') {
+      options.logTypes = [ 's', 'ss', 'f' ];
     }
 
     const auth0logger = new loggingTools.LogsProcessor(storage, options);


### PR DESCRIPTION
## ✏️ Changes
 `logs-to-segment` was initially designed to work with fixed log types. Restoring that in this change.