### PR TITLE
Fix for "Your client request is too large."

### DIFF
--- a/webtask-templates/mixpanel.json
+++ b/webtask-templates/mixpanel.json
@@ -17,8 +17,8 @@
       "type": "password"
     },
     "BATCH_SIZE": {
-      "description": "The amount of logs to be read on each execution. Maximum is 20.",
-      "default": 20
+      "description": "The amount of logs to be read on each execution. Maximum is 20. Default is 10",
+      "default": 10
     }
   }
 }


### PR DESCRIPTION
This is a fix for the "Your client request is too large" from Mixpanel. The default of 20 often creates messages that are too large to be accepted by MixPanel's servers. Moving this down to 10 lowers the risk.

This was the recommendation provided by Auth0 support on ticket [ref:_00D37JYbE._5001Gd48jY:ref]