### PR TITLE
Fix timestamp format for Splunk

### DIFF
--- a/server/lib/senders/splunk.js
+++ b/server/lib/senders/splunk.js
@@ -27,7 +27,8 @@ module.exports = () => {
     }
 
     logs.forEach(function(entry) {
-      Logger.send({ message: entry });
+      // The default time format in Splunk is epoch time format, in the format <sec>.<ms>
+      Logger.send({ message: entry, metadata: {time: new Date(entry.date).getTime()/1000} });
     });
 
     logger.info(`Sending ${logs.length} logs to Splunk...`);


### PR DESCRIPTION
When forwarding logs to Splunk, all logs in a batch contain the same timestamp.
In order to follow the log timestamp, Splunk metadata needs to have the correct timestamp, which can be retrieved from the 'date' entry.