### PR TITLE
[OPEX-527] Allow higher batch size

### DIFF
--- a/server/lib/processLogs.js
+++ b/server/lib/processLogs.js
@@ -71,7 +71,7 @@ module.exports = (storage) =>
       logger
     };
 
-    const maxBatchSize = (provider === 'mixpanel') ? 20 : 100;
+    const maxBatchSize = (provider === 'mixpanel') ? 20 : (options.batchSize || 100);
 
     if (!options.batchSize || options.batchSize > maxBatchSize) {
       options.batchSize = maxBatchSize;


### PR DESCRIPTION
## ✏️ Changes
  
This PR allows extensions to have a higher limit if present or a default of 100 if not.

MGMT API hard limit is of 100, this only would work if a higher limit is available in MGMT API.

## 🎯 Testing
  
 
✅ This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
✅ This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
 