### PR TITLE
[OPEX-527] Only allow new 1k limit, nothing else and bump dep version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-logs-to-provider",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1467,14 +1467,14 @@
       }
     },
     "auth0-log-extension-tools": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/auth0-log-extension-tools/-/auth0-log-extension-tools-1.3.6.tgz",
-      "integrity": "sha512-1hKi/jk/X+yej7hpGOcAMKPVcVFsbCCeUEDhLsjKdcMvkgoqSbSAs9o6r1opSZFq/oaNorm8tmvHULwIfQUl/g==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/auth0-log-extension-tools/-/auth0-log-extension-tools-1.3.7.tgz",
+      "integrity": "sha512-CVN9xi0v0KZ5pm9zJxDqsOY7kVeIAcf3NHdHWSH2ZHqJybFj08Dl/qWXSID8Zqt6+tctCVjcDiQ/uotAYpVmRQ==",
       "requires": {
         "auth0-extension-tools": "1.3.1",
         "bluebird": "3.4.6",
-        "lodash": "4.8.2",
-        "superagent": "1.2.0"
+        "lodash": "4.17.11",
+        "superagent": "3.8.3"
       },
       "dependencies": {
         "bluebird": {
@@ -1483,9 +1483,26 @@
           "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8="
         },
         "lodash": {
-          "version": "4.8.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.8.2.tgz",
-          "integrity": "sha1-R4rX/2SMPHGi9hCOAyxcDMQHR98="
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "superagent": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+          "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+          "requires": {
+            "component-emitter": "1.2.1",
+            "cookiejar": "2.1.1",
+            "debug": "3.1.0",
+            "extend": "3.0.1",
+            "form-data": "2.3.2",
+            "formidable": "1.2.1",
+            "methods": "1.1.2",
+            "mime": "1.6.0",
+            "qs": "6.5.1",
+            "readable-stream": "2.3.6"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-logs-to-provider",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "This extension will take all of your Auth0 logs and export them to any provider from the list.",
   "main": "index.js",
   "repository": {
@@ -80,7 +80,7 @@
     "auth0-extension-express-tools": "^1.1.9",
     "auth0-extension-tools": "1.3.1",
     "auth0-extension-ui": "^1.0.1",
-    "auth0-log-extension-tools": "^1.3.6",
+    "auth0-log-extension-tools": "^1.3.7",
     "auth0-oauth2-express": "^1.1.8",
     "aws-sdk": "2.197.0",
     "axios": "^0.15.0",

--- a/server/lib/processLogs.js
+++ b/server/lib/processLogs.js
@@ -71,7 +71,14 @@ module.exports = (storage) =>
       logger
     };
 
-    const maxBatchSize = (provider === 'mixpanel') ? 20 : (options.batchSize || 100);
+    let maxBatchSize = 100;
+
+    if (provider === 'mixpanel') {
+      maxBatchSize = 20;
+    }
+    else if (options.batchSize === 1000) {
+      maxBatchSize = options.batchSize;
+    }
 
     if (!options.batchSize || options.batchSize > maxBatchSize) {
       options.batchSize = maxBatchSize;


### PR DESCRIPTION
## ✏️ Changes
  
Only allow 1k if present, not a range to not break extensions und bump log-extension-tools to allow 1k to be propagated down the chain to the service.
  
## 🎯 Testing
     
✅ This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
✅ This change has been tested for performance
  
## 🚀 Deployment

✅ This can be deployed any time