### PR TITLE
Add a toggle for daily slack reports

### DIFF
--- a/server/lib/processLogs.js
+++ b/server/lib/processLogs.js
@@ -117,7 +117,9 @@ module.exports = (storage) =>
           const reportTime = config('DAILY_REPORT_TIME') || 16;
 
           if (data.lastReportDate !== now && new Date().getHours() >= reportTime) {
-            sendDailyReport(now);
+            if (config('SLACK_SEND_DAILY_REPORT') === true || config('SLACK_SEND_DAILY_REPORT') === 'true')) {
+              sendDailyReport(now);
+            }
           }
         })
     };

--- a/webtask-templates/common.json
+++ b/webtask-templates/common.json
@@ -41,6 +41,22 @@
         }
       ]
     },
+    "SLACK_SEND_DAILY_REPORT": {
+      "description": "This setting will enable daily reports on logs processed, errors and warnings.",
+      "type": "select",
+      "allowMultiple": false,
+      "default": "true",
+      "options": [
+        {
+          "value": "false",
+          "text": "No"
+        },
+        {
+          "value": "true",
+          "text": "Yes"
+        }
+      ]
+    },
     "LOG_LEVEL": {
       "description": "This allows you to specify the log level of events that need to be sent. Selected level includes all levels above.",
       "type": "select",


### PR DESCRIPTION
I would like to receive slack notification in the event of failures, however I would not like to receive the daily reports as they clutter the notification channel with no value.
My proposed solution is this configuration option.