### PR TITLE
OPEX-693 Fixing logo URLs for splunk and cloudwatch

### DIFF
--- a/webtask-templates/cloudwatch.json
+++ b/webtask-templates/cloudwatch.json
@@ -3,7 +3,7 @@
   "name": "logs-to-cloudwatch",
   "version": "2.2.1",
   "description": "This extension will take all of your Auth0 logs and export them to CloudWatch",
-  "logoUrl": "https://truesightpulse.bmc.com/wp-content/uploads/2016/11/cloudwatch.png",
+  "logoUrl": "https://cdn.auth0.com/extensions/auth0-logs-to-cloudwatch/assets/logo.png",
   "secrets": {
     "CLOUDWATCH_LOG_GROUP_NAME": {
       "description": "Cloudwatch Log Group Name",

--- a/webtask-templates/splunk.json
+++ b/webtask-templates/splunk.json
@@ -4,7 +4,7 @@
   "version": "2.3.1",
   "preVersion": "2.3.0",
   "description": "This extension will take all of your Auth0 logs and export them to Splunk",
-  "logoUrl": "https://cdn.auth0.com/extensions/auth0-logs-to-splunk/assets/logo.svg",
+  "logoUrl": "https://cdn.auth0.com/extensions/auth0-logs-to-splunk/assets/logo.png",
   "secrets": {
     "SPLUNK_URL": {
       "description": "Splunk URL - this is your Splunk HTTP Collector Endpoint",


### PR DESCRIPTION
The logo URLs were broken. This PR just adds them back