### PR TITLE
OPEX-941 - Fix Splunk retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-logs-to-provider",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "This extension will take all of your Auth0 logs and export them to any provider from the list.",
   "main": "index.js",
   "repository": {

--- a/webtask-templates/splunk.json
+++ b/webtask-templates/splunk.json
@@ -1,8 +1,8 @@
 {
   "title": "Auth0 Logs to Splunk",
   "name": "auth0-logs-to-splunk",
-  "version": "2.3.1",
-  "preVersion": "2.3.0",
+  "version": "2.3.2",
+  "preVersion": "2.3.1",
   "description": "This extension will take all of your Auth0 logs and export them to Splunk",
   "logoUrl": "https://cdn.auth0.com/extensions/auth0-logs-to-splunk/assets/logo.png",
   "secrets": {


### PR DESCRIPTION
Currently the Splunk extension ignores some types of Splunk errors. This PR fixes the retry logic to retry for all errors.
  
https://auth0team.atlassian.net/browse/OPEX-941
https://auth0.slack.com/archives/CEF1UL7UP/p1582150746112700
