### PR TITLE
ESD-6712: Add maximum value message to 13 log extensions.

### DIFF
--- a/webtask-templates/common.json
+++ b/webtask-templates/common.json
@@ -13,7 +13,7 @@
   },
   "secrets": {
     "BATCH_SIZE": {
-      "description": "The amount of logs to batch before sending. A single cron execution will send multiple batches. ALERT: the MAXIMUM value is 100 after which errors may occur.",
+      "description": "The amount of logs to batch before sending. A single cron execution will send multiple batches. ALERT: the maximum value is 100.",
       "default": 100
     },
     "START_FROM": {

--- a/webtask-templates/common.json
+++ b/webtask-templates/common.json
@@ -13,7 +13,7 @@
   },
   "secrets": {
     "BATCH_SIZE": {
-      "description": "The amount of logs to batch before sending. A single cron execution will send multiple batches.",
+      "description": "The amount of logs to batch before sending. A single cron execution will send multiple batches. PLEASE NOTE: the MAXIMUM value is 100 after which errors may occur.",
       "default": 100
     },
     "START_FROM": {

--- a/webtask-templates/common.json
+++ b/webtask-templates/common.json
@@ -13,7 +13,7 @@
   },
   "secrets": {
     "BATCH_SIZE": {
-      "description": "The amount of logs to batch before sending. A single cron execution will send multiple batches. PLEASE NOTE: the MAXIMUM value is 100 after which errors may occur.",
+      "description": "The amount of logs to batch before sending. A single cron execution will send multiple batches. ALERT: the MAXIMUM value is 100 after which errors may occur.",
       "default": 100
     },
     "START_FROM": {

--- a/webtask-templates/common.json
+++ b/webtask-templates/common.json
@@ -13,7 +13,7 @@
   },
   "secrets": {
     "BATCH_SIZE": {
-      "description": "The amount of logs to batch before sending. A single cron execution will send multiple batches. ALERT: the maximum value is 100.",
+      "description": "The amount of logs to batch before sending. A single cron execution will send multiple batches. The maximum value is 100.",
       "default": 100
     },
     "START_FROM": {


### PR DESCRIPTION
## ✏️ Changes
  
Following an ESD ticket that resulted when a customer exceeded max batch size, we are adding a UX warning so that customers can avoid this problem.

  
## 📷 Screenshots
 
BEFORE:

<img width="844" alt="Screen Shot 2020-06-10 at 11 53 53 PM" src="https://user-images.githubusercontent.com/26266456/84355357-5395b700-ab77-11ea-93c5-61aa063673f4.png">

AFTER:
My changes add the text, "The maximum value is 100.",  to the description in the BATCH_SIZE field. 
Screenshot pending.
  
## 🔗 References

https://auth0team.atlassian.net/browse/ESD-6712  
  
## 🎯 Testing
   
✅ 🛑 This change has been tested in a Webtask
   
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
