### PR TITLE
[ESD-6906] Fix hidden mutation in appinsights library

### DIFF
--- a/server/lib/senders/appinsights.js
+++ b/server/lib/senders/appinsights.js
@@ -16,7 +16,7 @@ const getClient = () => {
   // Override the original getEnvelope method to allow setting a custom time.
   const originalGetEnvelope = client.getEnvelope;
   client.getEnvelope = (data, tagOverrides) => {
-    let envelope = originalGetEnvelope.apply(client, [data, tagOverrides]);
+    let envelope = _.cloneDeep(originalGetEnvelope.apply(client, [data, tagOverrides]));
     envelope.time = data.baseData.properties.date;
     envelope.os = data.baseData.properties.os;
     envelope.osVer = data.baseData.properties.os_version;

--- a/webtask-templates/appinsights.json
+++ b/webtask-templates/appinsights.json
@@ -1,8 +1,8 @@
 {
   "title": "Auth0 Logs to Application Insights",
   "name": "auth0-logs-to-application-insights",
-  "version": "2.2.3",
-  "preVersion": "2.2.2",
+  "version": "2.2.4",
+  "preVersion": "2.2.3",
   "description": "This extension will take all of your Auth0 logs and export them to Application Insights",
   "docsUrl": "https://auth0.com/docs/extensions/application-insight",
   "logoUrl": "https://cdn.auth0.com/extensions/auth0-logs-to-application-insights/assets/logo.svg",


### PR DESCRIPTION
The envelope variable has a reference to the tags' context of the client, modifying tags modifies the default content for the whole client session, adding tags to logs that shouldn't have them.

In this PR we make a deep clone of the object to dismiss the reference.