### PR TITLE
ESD-8349: Add user-agent to headers in auth webhook extension

### DIFF
--- a/server/lib/senders/auth-webhooks.js
+++ b/server/lib/senders/auth-webhooks.js
@@ -9,7 +9,7 @@ module.exports = () => {
   const batchMode = config('SEND_AS_BATCH') === true || config('SEND_AS_BATCH') === 'true';
   const concurrentCalls = parseInt(config('WEBHOOK_CONCURRENT_CALLS'), 10) || 5;
   const headers = config('AUTHORIZATION') ? { Authorization: config('AUTHORIZATION') } : {};
-  headers['User-Agent'] = 'auth0-extensions/0.2.7 auth webhook';
+  headers['User-Agent'] = 'auth0-extensions auth webhook';
 
   const sendRequest = (data, callback) =>
     Request({

--- a/server/lib/senders/auth-webhooks.js
+++ b/server/lib/senders/auth-webhooks.js
@@ -9,6 +9,7 @@ module.exports = () => {
   const batchMode = config('SEND_AS_BATCH') === true || config('SEND_AS_BATCH') === 'true';
   const concurrentCalls = parseInt(config('WEBHOOK_CONCURRENT_CALLS'), 10) || 5;
   const headers = config('AUTHORIZATION') ? { Authorization: config('AUTHORIZATION') } : {};
+  headers['User-Agent'] = 'auth0-extensions/0.2.7 auth webhook';
 
   const sendRequest = (data, callback) =>
     Request({

--- a/webtask-templates/auth-webhooks.json
+++ b/webtask-templates/auth-webhooks.json
@@ -1,8 +1,8 @@
 {
   "title": "Auth0 Authentication API webhooks",
   "name": "auth0-authentication-api-webhooks",
-  "version": "2.3.3",
-  "preVersion": "2.3.2",
+  "version": "2.3.4",
+  "preVersion": "2.3.3",
   "description": "Allows you to define webhooks for Auth0's Authentication API. It will go through the audit logs and call a webhook for specific events.",
   "category": "webhook",
   "docsUrl": "https://auth0.com/docs/extensions/authentication-api-webhooks",


### PR DESCRIPTION
## ✏️ Changes
  
- The `request` library in this particular extension does not send a default `User-Agent` header.
- Resolves: https://github.com/auth0-extensions/auth0-logs-to-provider/issues/64
- This change adds a default `User-Agent` header to the request made from the extension.
  