### PR TITLE
Add successful/failed invitation events

### DIFF
--- a/webtask-templates/common.json
+++ b/webtask-templates/common.json
@@ -455,6 +455,14 @@
           "value": "ublkdu"
         },
         {
+          "text": "Successful invite accept",
+          "value": "si"
+        },
+        {
+          "text": "Failed invite accept",
+          "value": "fi"
+        },
+        {
           "text": "Success Login",
           "value": "sens"
         },


### PR DESCRIPTION
I'd like to use Auth0 Mixpanel extension for tracking some particular events that are not in this repo yet. Particularly, `si` and `fi` events. As far as I see, this is the way to go (I looked at the PR https://github.com/auth0-extensions/auth0-logs-to-provider/pull/48 )

For the full list of events, see https://auth0.com/docs/monitor-auth0/logs/log-event-type-codes